### PR TITLE
Replace tabs with 2 spaces in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,70 +168,70 @@ As it's stated in the TL;DR, there are already some sane defaults that you may l
 true_false_commands = false,
 cursor_by_mode = false,
 bottom = {
-	hidden_laststatus = 0,
-	hidden_ruler = false,
-	hidden_showmode = false,
-	hidden_showcmd = false,
-	hidden_cmdheight = 1,
+  hidden_laststatus = 0,
+  hidden_ruler = false,
+  hidden_showmode = false,
+  hidden_showcmd = false,
+  hidden_cmdheight = 1,
 
-	shown_laststatus = 2,
-	shown_ruler = true,
-	shown_showmode = false,
-	shown_showcmd = false,
-	shown_cmdheight = 1
+  shown_laststatus = 2,
+  shown_ruler = true,
+  shown_showmode = false,
+  shown_showcmd = false,
+  shown_cmdheight = 1
 },
 top = {
-	hidden_showtabline = 0,
+  hidden_showtabline = 0,
 
-	shown_showtabline = 2
+  shown_showtabline = 2
 },
 left = {
-	hidden_number = false,
-	hidden_relativenumber = false,
-	hidden_signcolumn = "no",
+  hidden_number = false,
+  hidden_relativenumber = false,
+  hidden_signcolumn = "no",
 
-	shown_number = true,
-	shown_relativenumber = false,
-	shown_signcolumn = "no"
+  shown_number = true,
+  shown_relativenumber = false,
+  shown_signcolumn = "no"
 },
 ataraxis = {
-	ideal_writing_area_width = 0,
-	just_do_it_for_me = false,
-	left_padding = 40,
-	right_padding = 40,
-	top_padding = 0,
-	bottom_padding = 0,
-	custome_bg = "",
-	disable_bg_configuration = false,
-	disable_fillchars_configuration = false,
-	force_when_plus_one_window = false,
-	force_hide_statusline = true
+  ideal_writing_area_width = 0,
+  just_do_it_for_me = false,
+  left_padding = 40,
+  right_padding = 40,
+  top_padding = 0,
+  bottom_padding = 0,
+  custome_bg = "",
+  disable_bg_configuration = false,
+  disable_fillchars_configuration = false,
+  force_when_plus_one_window = false,
+  force_hide_statusline = true
 },
 focus = {
-	margin_of_error = 5,
-	focus_method = "experimental"
+  margin_of_error = 5,
+  focus_method = "experimental"
 },
 minimalist = {
-	store_and_restore_settings = false,
-	show_vals_to_read = {}
+  store_and_restore_settings = false,
+  show_vals_to_read = {}
 },
 events = {
-	before_minimalist_mode_shown = false,
-	before_minimalist_mode_hidden = false,
-	after_minimalist_mode_shown = false,
-	after_minimalist_mode_hidden = false
+  before_minimalist_mode_shown = false,
+  before_minimalist_mode_hidden = false,
+  after_minimalist_mode_shown = false,
+  after_minimalist_mode_hidden = false
 },
 integrations = {
-	integration_galaxyline = false,
-	integration_vim_airline = false,
-	integration_vim_powerline = false,
-	integration_tmux = false,
-	integration_express_line = false,
-	integration_gitgutter = false,
-	integration_vim_signify = false,
-	integration_limelight = false,
-	integration_tzfocus_tzataraxis = false,
-	integration_gitsigns = false
+  integration_galaxyline = false,
+  integration_vim_airline = false,
+  integration_vim_powerline = false,
+  integration_tmux = false,
+  integration_express_line = false,
+  integration_gitgutter = false,
+  integration_vim_signify = false,
+  integration_limelight = false,
+  integration_tzfocus_tzataraxis = false,
+  integration_gitsigns = false
 }
 ```
 
@@ -247,74 +247,74 @@ local true_zen = require("true-zen")
 
 -- setup for TrueZen.nvim
 true_zen.setup({
-    true_false_commands = false,
-	cursor_by_mode = false,
-	bottom = {
-		hidden_laststatus = 0,
-		hidden_ruler = false,
-		hidden_showmode = false,
-		hidden_showcmd = false,
-		hidden_cmdheight = 1,
+  true_false_commands = false,
+  cursor_by_mode = false,
+  bottom = {
+    hidden_laststatus = 0,
+    hidden_ruler = false,
+    hidden_showmode = false,
+    hidden_showcmd = false,
+    hidden_cmdheight = 1,
 
-		shown_laststatus = 2,
-		shown_ruler = true,
-		shown_showmode = false,
-		shown_showcmd = false,
-		shown_cmdheight = 1
-	},
-	top = {
-		hidden_showtabline = 0,
+    shown_laststatus = 2,
+    shown_ruler = true,
+    shown_showmode = false,
+    shown_showcmd = false,
+    shown_cmdheight = 1
+  },
+  top = {
+    hidden_showtabline = 0,
 
-		shown_showtabline = 2
-	},
-	left = {
-		hidden_number = false,
-		hidden_relativenumber = false,
-		hidden_signcolumn = "no",
+    shown_showtabline = 2
+  },
+  left = {
+    hidden_number = false,
+    hidden_relativenumber = false,
+    hidden_signcolumn = "no",
 
-		shown_number = true,
-		shown_relativenumber = false,
-		shown_signcolumn = "no"
-	},
-	ataraxis = {
-		ideal_writing_area_width = 0,
-		just_do_it_for_me = false,
-		left_padding = 40,
-		right_padding = 40,
-		top_padding = 0,
-		bottom_padding = 0,
-		custome_bg = "",
-		disable_bg_configuration = false,
-		disable_fillchars_configuration = false,
-		force_when_plus_one_window = false,
-		force_hide_statusline = true
-	},
-	focus = {
-		margin_of_error = 5,
-		focus_method = "experimental"
-	},
-	minimalist = {
-		store_and_restore_settings = false,
-		show_vals_to_read = {}
-	},
-	events = {
-		before_minimalist_mode_shown = false,
-		before_minimalist_mode_hidden = false,
-		after_minimalist_mode_shown = false,
-		after_minimalist_mode_hidden = false
-	},
-	integrations = {
-		integration_galaxyline = false,
-		integration_vim_airline = false,
-		integration_vim_powerline = false,
-		integration_tmux = false,
-		integration_express_line = false,
-		integration_gitgutter = false,
-		integration_vim_signify = false,
-		integration_limelight = false,
-		integration_tzfocus_tzataraxis = false,
-		integration_gitsigns = false
-	}
+    shown_number = true,
+    shown_relativenumber = false,
+    shown_signcolumn = "no"
+  },
+  ataraxis = {
+    ideal_writing_area_width = 0,
+    just_do_it_for_me = false,
+    left_padding = 40,
+    right_padding = 40,
+    top_padding = 0,
+    bottom_padding = 0,
+    custome_bg = "",
+    disable_bg_configuration = false,
+    disable_fillchars_configuration = false,
+    force_when_plus_one_window = false,
+    force_hide_statusline = true
+  },
+  focus = {
+    margin_of_error = 5,
+    focus_method = "experimental"
+  },
+  minimalist = {
+    store_and_restore_settings = false,
+    show_vals_to_read = {}
+  },
+  events = {
+    before_minimalist_mode_shown = false,
+    before_minimalist_mode_hidden = false,
+    after_minimalist_mode_shown = false,
+    after_minimalist_mode_hidden = false
+  },
+  integrations = {
+    integration_galaxyline = false,
+    integration_vim_airline = false,
+    integration_vim_powerline = false,
+    integration_tmux = false,
+    integration_express_line = false,
+    integration_gitgutter = false,
+    integration_vim_signify = false,
+    integration_limelight = false,
+    integration_tzfocus_tzataraxis = false,
+    integration_gitsigns = false
+  }
 })
 ```
 <br />
@@ -331,74 +331,74 @@ local true_zen = require("true-zen")
 
 -- setup for TrueZen.nvim
 true_zen.setup({
-    true_false_commands = false,
-	cursor_by_mode = false,
-	bottom = {
-		hidden_laststatus = 0,
-		hidden_ruler = false,
-		hidden_showmode = false,
-		hidden_showcmd = false,
-		hidden_cmdheight = 1,
+  true_false_commands = false,
+  cursor_by_mode = false,
+  bottom = {
+    hidden_laststatus = 0,
+    hidden_ruler = false,
+    hidden_showmode = false,
+    hidden_showcmd = false,
+    hidden_cmdheight = 1,
 
-		shown_laststatus = 2,
-		shown_ruler = true,
-		shown_showmode = false,
-		shown_showcmd = false,
-		shown_cmdheight = 1
-	},
-	top = {
-		hidden_showtabline = 0,
+    shown_laststatus = 2,
+    shown_ruler = true,
+    shown_showmode = false,
+    shown_showcmd = false,
+    shown_cmdheight = 1
+  },
+  top = {
+    hidden_showtabline = 0,
 
-		shown_showtabline = 2
-	},
-	left = {
-		hidden_number = false,
-		hidden_relativenumber = false,
-		hidden_signcolumn = "no",
+    shown_showtabline = 2
+  },
+  left = {
+    hidden_number = false,
+    hidden_relativenumber = false,
+    hidden_signcolumn = "no",
 
-		shown_number = true,
-		shown_relativenumber = false,
-		shown_signcolumn = "no"
-	},
-	ataraxis = {
-		ideal_writing_area_width = 0,
-		just_do_it_for_me = false,
-		left_padding = 40,
-		right_padding = 40,
-		top_padding = 0,
-		bottom_padding = 0,
-		custome_bg = "",
-		disable_bg_configuration = false,
-		disable_fillchars_configuration = false,
-		force_when_plus_one_window = false,
-		force_hide_statusline = true
-	},
-	focus = {
-		margin_of_error = 5,
-		focus_method = "experimental"
-	},
-	minimalist = {
-		store_and_restore_settings = false,
-		show_vals_to_read = {}
-	},
-	events = {
-		before_minimalist_mode_shown = false,
-		before_minimalist_mode_hidden = false,
-		after_minimalist_mode_shown = false,
-		after_minimalist_mode_hidden = false
-	},
-	integrations = {
-		integration_galaxyline = false,
-		integration_vim_airline = false,
-		integration_vim_powerline = false,
-		integration_tmux = false,
-		integration_express_line = false,
-		integration_gitgutter = false,
-		integration_vim_signify = false,
-		integration_limelight = false,
-		integration_tzfocus_tzataraxis = false,
-		integration_gitsigns = false
-	}
+    shown_number = true,
+    shown_relativenumber = false,
+    shown_signcolumn = "no"
+  },
+  ataraxis = {
+    ideal_writing_area_width = 0,
+    just_do_it_for_me = false,
+    left_padding = 40,
+    right_padding = 40,
+    top_padding = 0,
+    bottom_padding = 0,
+    custome_bg = "",
+    disable_bg_configuration = false,
+    disable_fillchars_configuration = false,
+    force_when_plus_one_window = false,
+    force_hide_statusline = true
+  },
+  focus = {
+    margin_of_error = 5,
+    focus_method = "experimental"
+  },
+  minimalist = {
+    store_and_restore_settings = false,
+    show_vals_to_read = {}
+  },
+  events = {
+    before_minimalist_mode_shown = false,
+    before_minimalist_mode_hidden = false,
+    after_minimalist_mode_shown = false,
+    after_minimalist_mode_hidden = false
+  },
+  integrations = {
+    integration_galaxyline = false,
+    integration_vim_airline = false,
+    integration_vim_powerline = false,
+    integration_tmux = false,
+    integration_express_line = false,
+    integration_gitgutter = false,
+    integration_vim_signify = false,
+    integration_limelight = false,
+    integration_tzfocus_tzataraxis = false,
+    integration_gitsigns = false
+  }
 })
 EOF
 ```
@@ -488,19 +488,19 @@ The code that executes in any of this circumstances is set by a function by the 
 local true_zen = require("true-zen")
 
 true_zen.after_minimalist_mode_hidden = function ()
-	vim.cmd("echo 'I ran after minimalist mode hid everything :)'")
+  vim.cmd("echo 'I ran after minimalist mode hid everything :)'")
 end
 
 true_zen.before_minimalist_mode_hidden = function ()
-	vim.cmd("echo 'I ran before minimalist mode hid everything :)'")
+  vim.cmd("echo 'I ran before minimalist mode hid everything :)'")
 end
 
 true_zen.after_minimalist_mode_shown = function ()
-	vim.cmd("echo 'I ran after minimalist mode showed everything :)'")
+  vim.cmd("echo 'I ran after minimalist mode showed everything :)'")
 end
 
 true_zen.before_minimalist_mode_shown = function ()
-	vim.cmd("echo 'I ran before minimalist mode showed everything :)'")
+  vim.cmd("echo 'I ran before minimalist mode showed everything :)'")
 end
 
 ```
@@ -550,10 +550,10 @@ Note for Vim Powerline users: toggling/untoggling your statusline is a little bi
 
 ```
 minimalist = {
-	store_and_restore_settings = true,
-	show_vals_to_read = {
-		"shown_showtabline"
-	}
+  store_and_restore_settings = true,
+  show_vals_to_read = {
+    "shown_showtabline"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ left = {
 	shown_signcolumn = "no"
 },
 ataraxis = {
-	ideal_writing_area_width = 0
+	ideal_writing_area_width = 0,
 	just_do_it_for_me = false,
 	left_padding = 40,
 	right_padding = 40,

--- a/lua/true-zen/init.lua
+++ b/lua/true-zen/init.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local opts = require("true-zen.config").options
 local cmd = vim.cmd
@@ -51,24 +51,24 @@ local function setup_cursor()
 end
 
 
-function before_minimalist_mode_shown()
+function M.before_minimalist_mode_shown()
 	
 end
 
-function before_minimalist_mode_hidden()
+function M.before_minimalist_mode_hidden()
 	
 end
 
-function after_minimalist_mode_shown()
+function M.after_minimalist_mode_shown()
 	
 end
 
-function after_minimalist_mode_hidden()
+function M.after_minimalist_mode_hidden()
 	
 end
 
 
-function setup(custom_opts)
+function M.setup(custom_opts)
 	require("true-zen.config").set_options(custom_opts)
 	setup_commands()
 	setup_cursor()
@@ -76,10 +76,4 @@ end
 
 
 
-return {
-	setup = setup,
-	before_minimalist_mode_shown = before_minimalist_mode_shown,
-	before_minimalist_mode_hidden = before_minimalist_mode_hidden,
-	after_minimalist_mode_shown = after_minimalist_mode_shown,
-	after_minimalist_mode_hidden = after_minimalist_mode_hidden
-}
+return M

--- a/lua/true-zen/main.lua
+++ b/lua/true-zen/main.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local bottom = require("true-zen.services.bottom.init")
 local top = require("true-zen.services.top.init")
@@ -13,7 +13,7 @@ local resume = require("true-zen.services.resume.init")
 local cmd  = vim.cmd
 
 
-function main(option, command_option)
+function M.main(option, command_option)
 
 	option = option or 0
 	command_option = command_option or 0
@@ -38,8 +38,4 @@ end
 
 
 -- export the functions
-return {
-	-- toggle_statusline = toggle_statusline, -- called with TZStatusline
-	main = main
-}
-
+return M

--- a/lua/true-zen/services/bottom/init.lua
+++ b/lua/true-zen/services/bottom/init.lua
@@ -1,38 +1,38 @@
-
+local M = {}
 
 local service = require("true-zen.services.bottom.service")
 local cmd = vim.cmd
 
 -- show and hide bottom funcs
 local function bottom_true()
-	bottom_show = 1
+	M.bottom_show = 1
 	service.bottom_true()
 end
 
 local function bottom_false()
-	bottom_show = 0
+	M.bottom_show = 0
 	service.bottom_false()
 end
 
 local function toggle()
-	bottom_show = vim.api.nvim_eval("&laststatus > 0")
-	if (bottom_show == 1) then				-- bottom true, shown; thus, hide
+	M.bottom_show = vim.api.nvim_eval("&laststatus > 0")
+	if (M.bottom_show == 1) then				-- bottom true, shown; thus, hide
 		bottom_false()
-	elseif (bottom_show == 0) then			-- bottom false, hidden; thus, show
+	elseif (M.bottom_show == 0) then			-- bottom false, hidden; thus, show
 		bottom_true()
 	else
 		-- nothing
 	end
 end
 
-function resume()
+function M.resume()
 
-	if (bottom_show == 1) then				-- bottm true; shown
+	if (M.bottom_show == 1) then				-- bottm true; shown
 		bottom_true()
-	elseif (bottom_show == 0) then			-- status line false; hidden
+	elseif (M.bottom_show == 0) then			-- status line false; hidden
 		bottom_false()
-	elseif (bottom_show == nil) then			-- show var is nil
-		bottom_show = vim.api.nvim_eval("&laststatus > 0")
+	elseif (M.bottom_show == nil) then			-- show var is nil
+		M.bottom_show = vim.api.nvim_eval("&laststatus > 0")
 		-- bottom_true()
 	else
 		cmd("echo 'none of the above'")
@@ -41,7 +41,7 @@ function resume()
 end
 
 
-function main(option)
+function M.main(option)
 
 	option = option or 0
 
@@ -64,8 +64,4 @@ end
 -- 	augroup END
 -- ]], false)
 
-return {
-	main = main,
-	resume = resume,
-	bottom_show = bottom_show
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_express_line.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_express_line.lua
@@ -1,21 +1,18 @@
-
+local M = {}
 
 
 local api = vim.api
 
 
 
-function enable_element()
+function M.enable_element()
 	require('el').setup()
 end
 
-function disable_element()
+function M.disable_element()
 	-- nothing
 end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_galaxyline.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_galaxyline.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local api = vim.api
 local cmd = vim.cmd
@@ -6,12 +6,12 @@ local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	require('galaxyline').load_galaxyline()
 	require('galaxyline').galaxyline_augroup()
 end
 
-function disable_element()
+function M.disable_element()
 	require("galaxyline").disable_galaxyline()
 	require("galaxyline").inactive_galaxyline()
 	cmd("setlocal statusline=-")
@@ -19,7 +19,4 @@ end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_gitgutter.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_gitgutter.lua
@@ -1,21 +1,18 @@
-
+local M = {}
 
 
 local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	cmd("silent! GitGutterEnable")
 end
 
-function disable_element()
+function M.disable_element()
 	cmd("silent! GitGutterDisable")
 end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_gitsigns.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_gitsigns.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 
 local api = vim.api
@@ -6,7 +6,7 @@ local cmd = vim.cmd
 
 
 
-function toggle_element(element)
+function M.toggle_element(element)
 
 	if (element == 0) then			-- current line blame
 		cmd("Gitsigns toggle_current_line_blame")
@@ -22,6 +22,4 @@ end
 
 
 
-return {
-	toggle_element = toggle_element,
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_limelight.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_limelight.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 
 
@@ -6,17 +6,14 @@ local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	cmd("Limelight")
 end
 
-function disable_element()
+function M.disable_element()
 	cmd("Limelight!")
 end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_tmux.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_tmux.lua
@@ -1,20 +1,17 @@
-
+local M = {}
 
 local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	cmd("silent !tmux set -g status on")
 end
 
-function disable_element()
+function M.disable_element()
 	cmd("silent !tmux set -g status off")
 end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_vim_airline.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_vim_airline.lua
@@ -1,15 +1,15 @@
-
+local M = {}
 
 
 local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	cmd("AirlineToggle")
 end
 
-function disable_element()
+function M.disable_element()
 	cmd("AirlineToggle")
 	cmd("silent! AirlineRefresh")
     cmd("silent! AirlineRefresh")
@@ -17,7 +17,4 @@ end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_vim_powerline.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_vim_powerline.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 
 
@@ -6,12 +6,12 @@ local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	cmd("doautocmd PowerlineStartup VimEnter")
 	cmd("silent! PowerlineReloadColorscheme")
 end
 
-function disable_element()
+function M.disable_element()
 	cmd("augroup PowerlineMain")
 	cmd("autocmd!")
 	cmd("augroup END")
@@ -20,7 +20,4 @@ end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/integrations/integration_vim_signify.lua
+++ b/lua/true-zen/services/bottom/integrations/integration_vim_signify.lua
@@ -1,21 +1,18 @@
-
+local M = {}
 
 
 local cmd = vim.cmd
 
 
 
-function enable_element()
+function M.enable_element()
 	cmd("SignifyToggle")
 end
 
-function disable_element()
+function M.disable_element()
 	cmd("SignifyToggle")
 end
 
 
 
-return {
-	enable_element = enable_element,
-	disable_element = disable_element
-}
+return M

--- a/lua/true-zen/services/bottom/service.lua
+++ b/lua/true-zen/services/bottom/service.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 
 local opts = require("true-zen.config").options
@@ -13,18 +13,15 @@ local cmd_settings = require("true-zen.utils.cmd_settings")
 -- set noshowcmd
 -- set cmdheight=1
 
-function bottom_true()		-- show
+function M.bottom_true()		-- show
 	cmd_settings.map_settings(opts["bottom"], true, "BOTTOM")
 end
 
-function bottom_false()		-- don't show
+function M.bottom_false()		-- don't show
 	cmd_settings.map_settings(opts["bottom"], false, "BOTTOM")
 end
 
 
 
-return {
-	bottom_true = bottom_true,
-	bottom_false = bottom_false
-}
+return M
 

--- a/lua/true-zen/services/left/init.lua
+++ b/lua/true-zen/services/left/init.lua
@@ -1,35 +1,35 @@
-
+local M = {}
 
 local service = require("true-zen.services.left.service")
 local cmd = vim.cmd
 
 -- show and hide left funcs
 local function left_true()
-	left_show = 1
+	M.left_show = 1
 	service.left_true()
 end
 
 local function left_false()
-	left_show = 0
+	M.left_show = 0
 	service.left_false()
 end
 
 local function toggle()
 
-	if (left_show == 1) then				-- left true; being shown
+	if (M.left_show == 1) then				-- left true; being shown
 		left_false()
-	elseif (left_show == 0) then			-- left false; being hidden
+	elseif (M.left_show == 0) then			-- left false; being hidden
 		left_true()
-	elseif (left_show == nil) then			-- show var is nil
-		left_show = vim.api.nvim_eval("&number > 0 || &relativenumber > 0")
+	elseif (M.left_show == nil) then			-- show var is nil
+		M.left_show = vim.api.nvim_eval("&number > 0 || &relativenumber > 0")
 		if (vim.api.nvim_eval("&number > 0 || &relativenumber > 0") == 1) then
-			left_show = 1
+			M.left_show = 1
 			toggle()
 		elseif (vim.api.nvim_eval("&signcolumn") == "yes") then
-			left_show = 1
+			M.left_show = 1
 			toggle()
 		else
-			left_show = 0
+			M.left_show = 0
 			toggle()
 		end
 	else
@@ -41,23 +41,23 @@ local function toggle()
 
 end
 
-function resume()
+function M.resume()
 
-	if (left_show == 1) then				-- left true; shown
+	if (M.left_show == 1) then				-- left true; shown
 		left_true()
-	elseif (left_show == 0) then			-- left false; hidden
+	elseif (M.left_show == 0) then			-- left false; hidden
 		left_false()
-	elseif (left_show == nil) then			-- show var is nil
-		left_show = vim.api.nvim_eval("&number > 0 || &relativenumber > 0")
+	elseif (M.left_show == nil) then			-- show var is nil
+		M.left_show = vim.api.nvim_eval("&number > 0 || &relativenumber > 0")
 		if (vim.api.nvim_eval("&number > 0 || &relativenumber > 0") == 1) then
-			left_show = 1
-			resume()
+			M.left_show = 1
+			M.resume()
 		elseif (vim.api.nvim_eval("&signcolumn") == "yes") then
-			left_show = 1
-			resume()
+			M.left_show = 1
+			M.resume()
 		else
-			left_show = 0
-			resume()
+			M.left_show = 0
+			M.resume()
 		end
 	else
 		cmd("echo 'none of the above'")
@@ -66,7 +66,7 @@ function resume()
 end
 
 
-function main(option)
+function M.main(option)
 
 	option = option or 0
 
@@ -82,8 +82,4 @@ function main(option)
 end
 
 
-return {
-	main = main,
-	resume = resume,
-	left_show = left_show
-}
+return M

--- a/lua/true-zen/services/left/service.lua
+++ b/lua/true-zen/services/left/service.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local opts = require("true-zen.config").options
 local cmd_settings = require("true-zen.utils.cmd_settings")
@@ -8,17 +8,14 @@ local cmd_settings = require("true-zen.utils.cmd_settings")
 -- set relativenumber
 -- set signcolumn=no
 
-function left_true()		-- show
+function M.left_true()		-- show
 	cmd_settings.map_settings(opts["left"], true, "LEFT")
 end
 
-function left_false()		-- hide
+function M.left_false()		-- hide
 	cmd_settings.map_settings(opts["left"], false, "LEFT")
 end
 
 
 
-return {
-	left_true = left_true,
-	left_false = left_false
-}
+return M

--- a/lua/true-zen/services/mode-ataraxis/init.lua
+++ b/lua/true-zen/services/mode-ataraxis/init.lua
@@ -1,3 +1,4 @@
+local M = {}
 
 local service = require("true-zen.services.mode-ataraxis.service")
 
@@ -6,33 +7,33 @@ local api = vim.api
 
 -- show and hide ataraxis funcs
 local function ataraxis_true()
-	ataraxis_show = 1
+	M.ataraxis_show = 1
 	service.ataraxis_true()
 end
 
 local function ataraxis_false()
-	ataraxis_show = 0
+	M.ataraxis_show = 0
 	service.ataraxis_false()
 end
 
 -- 1 if being shown
 -- 0 if being hidden
 local function toggle()
-	if (ataraxis_show == 1) then				-- ataraxis true, shown; thus, hide
+	if (M.ataraxis_show == 1) then				-- ataraxis true, shown; thus, hide
 		ataraxis_false()
-	elseif (ataraxis_show == 0) then			-- ataraxis false, hidden; thus, show
+	elseif (M.ataraxis_show == 0) then			-- ataraxis false, hidden; thus, show
 		ataraxis_true()
-	elseif (ataraxis_show == nil) then
-		ataraxis_show = 1
+	elseif (M.ataraxis_show == nil) then
+		M.ataraxis_show = 1
 		ataraxis_false()
 	else
-		ataraxis_show = 1
+		M.ataraxis_show = 1
 		ataraxis_false()
 	end
 end
 
 
-function main(option)
+function M.main(option)
 
 	option = option or 0
 
@@ -48,7 +49,4 @@ function main(option)
 end
 
 
-return {
-	main = main,
-	ataraxis_show = ataraxis_show
-}
+return M

--- a/lua/true-zen/services/mode-ataraxis/modules/fillchar.lua
+++ b/lua/true-zen/services/mode-ataraxis/modules/fillchar.lua
@@ -1,11 +1,11 @@
-
-
+local M = {}
+local fillchars_stored, final_fillchars
 
 local cmd = vim.cmd
 
 
 
-function set_fillchars()
+function M.set_fillchars()
 
 	cmd([[set fillchars+=stl:\ ]])
 	cmd([[set fillchars+=stlnc:\ ]])
@@ -21,7 +21,7 @@ function set_fillchars()
 end
 
 
-function store_fillchars()
+function M.store_fillchars()
 
 	local fillchars = vim.api.nvim_eval("&fillchars")
 
@@ -29,9 +29,9 @@ function store_fillchars()
 		-- vim's default fillchars
 		final_fillchars = [[stl:\ ,stlnc:\ ,vert:\│,fold:·,foldopen:-,foldclose:+,foldsep:\|,diff:-,msgsep:\ ,eob:~]]
 	else
-		fillchars_escaped_spaces = fillchars:gsub( ": ", ":\\ ")
-		fillchars_escaped_thicc_pipes = fillchars_escaped_spaces:gsub(":│", [[:\│]])
-		fillchars_escaped_thin_pipes = fillchars_escaped_thicc_pipes:gsub(":|", [[:\|]])
+		local fillchars_escaped_spaces = fillchars:gsub( ": ", ":\\ ")
+		local fillchars_escaped_thicc_pipes = fillchars_escaped_spaces:gsub(":│", [[:\│]])
+		local fillchars_escaped_thin_pipes = fillchars_escaped_thicc_pipes:gsub(":|", [[:\|]])
 		final_fillchars = fillchars_escaped_thin_pipes
 	end
 
@@ -39,7 +39,7 @@ function store_fillchars()
 	
 end
 
-function restore_fillchars()
+function M.restore_fillchars()
 
 	if (fillchars_stored == true) then
 		cmd("set fillchars="..final_fillchars.."")
@@ -49,10 +49,6 @@ end
 
 
 
-return {
-	set_fillchars = set_fillchars,
-	store_fillchars = store_fillchars,
-	restore_fillchars = restore_fillchars
-}
+return M
 
 

--- a/lua/true-zen/services/mode-ataraxis/modules/hi_group.lua
+++ b/lua/true-zen/services/mode-ataraxis/modules/hi_group.lua
@@ -1,10 +1,11 @@
-
+local M = {}
+local hi_groups_stored, hi_groups, terms
 
 
 local cmd = vim.cmd
 
 
-function set_hi_groups(custome_bg)
+function M.set_hi_groups(custome_bg)
 
 	custome_bg = custome_bg or ''
 
@@ -53,7 +54,7 @@ function set_hi_groups(custome_bg)
 	cmd(call_tran)
 end
 
-function store_hi_groups()
+function M.store_hi_groups()
 
 	vim.api.nvim_exec([[
 		function! ReturnHighlightTerm(group, term)
@@ -108,7 +109,7 @@ function store_hi_groups()
 end
 
 
-function restore_hi_groups()
+function M.restore_hi_groups()
 
 	if (hi_groups_stored == false or hi_groups_stored == nil) then
 
@@ -123,7 +124,7 @@ function restore_hi_groups()
 				-- cmd("echo 'Index = "..tostring(inner_hi_index).."; Value = "..tostring(hi_groups[hi_index][inner_hi_index]).."'")
 			
 				-- we need to construct the cmd like so:
-				current_term = terms[inner_hi_index]
+				local current_term = terms[inner_hi_index]
 				list_of_terms = list_of_terms.." "..current_term.."="..tostring(hi_groups[hi_index][inner_hi_index])..""
 
 			end
@@ -138,9 +139,5 @@ end
 
 
 
-return {
-	set_hi_groups = set_hi_groups,
-	store_hi_groups = store_hi_groups,
-	restore_hi_groups = restore_hi_groups
-}
+return M
 

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -602,6 +602,7 @@ function ataraxis_false()		-- hide
 		cmd(top_padding_cmd)
 		cmd("setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile nocursorline nocursorcolumn nonumber norelativenumber noruler noshowmode noshowcmd laststatus=0")
 
+		cmd("echo 'Top = "..tz_top_padding.."'")
 		-- cmd("unlet g:tz_top_padding")
 
 		-- return to middle buffer
@@ -636,6 +637,7 @@ function ataraxis_false()		-- hide
 		cmd(bottom_padding_cmd)
 		cmd("setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile nocursorline nocursorcolumn nonumber norelativenumber noruler noshowmode noshowcmd laststatus=0")
 
+		cmd("echo 'Bottom = "..tz_bottom_padding.."'")
 
 		-- cmd("unlet g:tz_bottom_padding")
 

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -313,6 +313,9 @@ function ataraxis_true()		-- show
 		cmd("q")
 
 
+		cmd("echo 'Top = "..tz_top_padding.."'")
+		cmd("echo 'Bottom = "..tz_bottom_padding.."'")
+
 		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tz_top_padding > 0) then
 			cmd("wincmd k")
 			cmd("q")

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -311,53 +311,6 @@ function ataraxis_true()		-- show
 		cmd("q")
 		cmd("wincmd l")
 		cmd("q")
-
-
-		-- if (top_use_passed_params == true) then
-		-- 	cmd("unlet g:tz_top_padding")
-		-- 	top_use_passed_params = false
-		-- 	cmd("wincmd k")
-		-- 	cmd("q")
-		-- else
-		-- 	if (opts["ataraxis"]["top_padding"] > 0) then
-		-- 		cmd("wincmd k")
-		-- 		cmd("q")
-		-- 	else
-		-- 		-- nothing
-		-- 	end
-		-- end
-
-
-		-- if (bottom_use_passed_params == true) then
-		-- 	cmd("unlet g:tz_bottom_padding")
-		-- 	bottom_use_passed_params = false
-		-- end
-
-
-
-		-- cmd("echo 'Top = "..tz_top_padding.."'")
-		-- cmd("echo 'Bottom = "..tz_bottom_padding.."'")
-
-		-- if (opts["ataraxis"]["top_padding"] > 0) then
-		-- 	cmd("wincmd k")
-		-- 	cmd("q")
-
-
-		-- else
-		-- 	-- nothing
-		-- end
-
-		-- if (opts["ataraxis"]["bottom_padding"] > 0 or tz_bottom_padding ~= "NONE" and tz_bottom_padding > 0) then
-		-- 	cmd("wincmd j")
-		-- 	cmd("q")
-
-		-- 	if (bottom_use_passed_params == true) then
-		-- 		cmd("unlet g:tz_bottom_padding")
-		-- 		bottom_use_passed_params = false
-		-- 	end
-		-- else
-		-- 	-- nothing
-		-- end
 		
 
 		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tonumber(tz_top_padding) > 0) then

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -313,14 +313,14 @@ function ataraxis_true()		-- show
 		cmd("q")
 
 
-		if (opts["ataraxis"]["top_padding"] > 0) then
+		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tz_top_padding > 0) then
 			cmd("wincmd k")
 			cmd("q")
 		else
 			-- nothing
 		end
 
-		if (opts["ataraxis"]["bottom_padding"] > 0) then
+		if (opts["ataraxis"]["bottom_padding"] > 0 or tz_bottom_padding ~= "NONE" and tz_bottom_padding > 0) then
 			cmd("wincmd j")
 			cmd("q")
 		else

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -316,6 +316,12 @@ function ataraxis_true()		-- show
 		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tz_top_padding > 0) then
 			cmd("wincmd k")
 			cmd("q")
+
+			if (top_use_passed_params == true) then
+				cmd("unlet g:tz_top_padding")
+				top_use_passed_params = false
+			end
+
 		else
 			-- nothing
 		end
@@ -323,6 +329,11 @@ function ataraxis_true()		-- show
 		if (opts["ataraxis"]["bottom_padding"] > 0 or tz_bottom_padding ~= "NONE" and tz_bottom_padding > 0) then
 			cmd("wincmd j")
 			cmd("q")
+
+			if (bottom_use_passed_params == true) then
+				cmd("unlet g:tz_bottom_padding")
+				bottom_use_passed_params = false
+			end
 		else
 			-- nothing
 		end
@@ -591,10 +602,12 @@ function ataraxis_false()		-- hide
 		cmd(top_padding_cmd)
 		cmd("setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile nocursorline nocursorcolumn nonumber norelativenumber noruler noshowmode noshowcmd laststatus=0")
 
-		cmd("unlet g:tz_top_padding")
+		-- cmd("unlet g:tz_top_padding")
 
 		-- return to middle buffer
 		cmd("wincmd j")
+
+		top_use_passed_params = true
 	else
 		if (opts["ataraxis"]["top_padding"] > 0) then
 			-- local top_padding_cmd = "resize "..opts["ataraxis"]["top_padding"]..""
@@ -624,10 +637,11 @@ function ataraxis_false()		-- hide
 		cmd("setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile nocursorline nocursorcolumn nonumber norelativenumber noruler noshowmode noshowcmd laststatus=0")
 
 
-		cmd("unlet g:tz_bottom_padding")
+		-- cmd("unlet g:tz_bottom_padding")
 
 		-- return to middle buffer
 		cmd("wincmd k")
+		bottom_use_passed_params = true
 	else
 		if (opts["ataraxis"]["bottom_padding"] > 0) then
 			-- local bottom_padding_cmd = "resize "..opts["ataraxis"]["bottom_padding"]..""

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -358,8 +358,9 @@ function ataraxis_true()		-- show
 		-- else
 		-- 	-- nothing
 		-- end
+		
 
-		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tz_top_padding > 0) then
+		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tonumber(tz_top_padding) > 0) then
 			cmd("wincmd k")
 			cmd("q")
 
@@ -372,7 +373,7 @@ function ataraxis_true()		-- show
 			-- nothing
 		end
 
-		if (opts["ataraxis"]["bottom_padding"] > 0 or tz_bottom_padding ~= "NONE" and tz_bottom_padding > 0) then
+		if (opts["ataraxis"]["bottom_padding"] > 0 or tz_bottom_padding ~= "NONE" and tonumber(tz_bottom_padding) > 0) then
 			cmd("wincmd j")
 			cmd("q")
 

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -1,4 +1,12 @@
-
+local M = {}
+local has_statusline_with_integration
+local gs_ps_current_line_blame, gs_ps_numhl, gs_ps_linehl, gs_ps_signs
+local top_use_passed_params, bottom_use_passed_params
+local is_splitbelow_set, is_splitright_set
+local top_has_been_stored, bottom_has_been_stored, left_has_been_stored
+local tz_top_padding, tz_left_padding, tz_right_padding, tz_bottom_padding
+local current_statusline
+local total_left_right_width
 
 local opts = require("true-zen.config").options
 local left_service = require("true-zen.services.left.service")
@@ -34,6 +42,7 @@ vim.api.nvim_exec([[
 
 
 
+-- TODO Refactor this
 function load_integrations(state)
 
 	state = state or false
@@ -300,7 +309,7 @@ function load_integrations(state)
 end
 
 
-function ataraxis_true()		-- show
+function M.ataraxis_true()		-- show
 
 	local amount_wins = vim.api.nvim_eval("winnr('$')")
 
@@ -454,7 +463,7 @@ function ataraxis_true()		-- show
 end
 
 
-function ataraxis_false()		-- hide
+function M.ataraxis_false()		-- hide
 
 	local amount_wins = vim.api.nvim_eval("winnr('$')")
 
@@ -528,7 +537,7 @@ function ataraxis_false()		-- hide
 	local top_padding_cmd = ""
 	local bottom_padding_cmd = ""
 
-	test_ideal_writing_and_just_me = function()
+	local test_ideal_writing_and_just_me = function()
 		
 		if (opts["ataraxis"]["ideal_writing_area_width"] > 0) then
 			-- stuff
@@ -770,7 +779,4 @@ end
 
 
 
-return {
-	ataraxis_true = ataraxis_true,
-	ataraxis_false = ataraxis_false
-}
+return M

--- a/lua/true-zen/services/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/mode-ataraxis/service.lua
@@ -313,8 +313,51 @@ function ataraxis_true()		-- show
 		cmd("q")
 
 
-		cmd("echo 'Top = "..tz_top_padding.."'")
-		cmd("echo 'Bottom = "..tz_bottom_padding.."'")
+		-- if (top_use_passed_params == true) then
+		-- 	cmd("unlet g:tz_top_padding")
+		-- 	top_use_passed_params = false
+		-- 	cmd("wincmd k")
+		-- 	cmd("q")
+		-- else
+		-- 	if (opts["ataraxis"]["top_padding"] > 0) then
+		-- 		cmd("wincmd k")
+		-- 		cmd("q")
+		-- 	else
+		-- 		-- nothing
+		-- 	end
+		-- end
+
+
+		-- if (bottom_use_passed_params == true) then
+		-- 	cmd("unlet g:tz_bottom_padding")
+		-- 	bottom_use_passed_params = false
+		-- end
+
+
+
+		-- cmd("echo 'Top = "..tz_top_padding.."'")
+		-- cmd("echo 'Bottom = "..tz_bottom_padding.."'")
+
+		-- if (opts["ataraxis"]["top_padding"] > 0) then
+		-- 	cmd("wincmd k")
+		-- 	cmd("q")
+
+
+		-- else
+		-- 	-- nothing
+		-- end
+
+		-- if (opts["ataraxis"]["bottom_padding"] > 0 or tz_bottom_padding ~= "NONE" and tz_bottom_padding > 0) then
+		-- 	cmd("wincmd j")
+		-- 	cmd("q")
+
+		-- 	if (bottom_use_passed_params == true) then
+		-- 		cmd("unlet g:tz_bottom_padding")
+		-- 		bottom_use_passed_params = false
+		-- 	end
+		-- else
+		-- 	-- nothing
+		-- end
 
 		if (opts["ataraxis"]["top_padding"] > 0 or tz_top_padding ~= "NONE" and tz_top_padding > 0) then
 			cmd("wincmd k")
@@ -340,6 +383,34 @@ function ataraxis_true()		-- show
 		else
 			-- nothing
 		end
+
+
+
+		-- if (opts["ataraxis"]["top_padding"] > 0) then
+		-- 	cmd("wincmd k")
+		-- 	cmd("q")
+
+
+		-- else
+		-- 	-- nothing
+		-- end
+
+		-- if (opts["ataraxis"]["bottom_padding"] > 0) then
+		-- 	cmd("wincmd j")
+		-- 	cmd("q")
+
+		-- 	if (bottom_use_passed_params == true) then
+		-- 		cmd("unlet g:tz_bottom_padding")
+		-- 		bottom_use_passed_params = false
+		-- 	end
+		-- else
+		-- 	-- nothing
+		-- end
+
+
+
+
+
 
 		-- mode_minimalist.main(1)
 		cmd("set fillchars=")
@@ -492,10 +563,10 @@ function ataraxis_false()		-- hide
 	-------------------------=== Integrations ===------------------------
 
 
-	local tz_top_padding = vim.api.nvim_eval([[get(g:,"tz_top_padding", "NONE")]])
-	local tz_left_padding = vim.api.nvim_eval([[get(g:,"tz_left_padding", "NONE")]])
-	local tz_right_padding = vim.api.nvim_eval([[get(g:,"tz_right_padding", "NONE")]])
-	local tz_bottom_padding = vim.api.nvim_eval([[get(g:, "tz_bottom_padding", "NONE")]])
+	tz_top_padding = vim.api.nvim_eval([[get(g:,"tz_top_padding", "NONE")]])
+	tz_left_padding = vim.api.nvim_eval([[get(g:,"tz_left_padding", "NONE")]])
+	tz_right_padding = vim.api.nvim_eval([[get(g:,"tz_right_padding", "NONE")]])
+	tz_bottom_padding = vim.api.nvim_eval([[get(g:, "tz_bottom_padding", "NONE")]])
 
 
 	local left_padding_cmd = ""

--- a/lua/true-zen/services/mode-focus/init.lua
+++ b/lua/true-zen/services/mode-focus/init.lua
@@ -1,4 +1,5 @@
-
+local M = {}
+local focus_show, ataraxis_is_toggled
 
 local service = require("true-zen.services.mode-focus.service")
 local opts = require("true-zen.config").options
@@ -107,7 +108,7 @@ local function toggle()
 				local current_window_width = vim.api.nvim_eval("winwidth('%')")
 				local total_current_window = tonumber(current_window_width) + tonumber(current_window_height)
 
-				difference = total_current_session - total_current_window
+				local difference = total_current_session - total_current_window
 
 				
 				for i = 1, tonumber(opts["focus"]["margin_of_error"]), 1 do
@@ -141,7 +142,7 @@ local function toggle()
 end
 
 
-function main(option)
+function M.main(option)
 
 	option = option or 0
 
@@ -157,6 +158,4 @@ function main(option)
 end
 
 
-return {
-	main = main
-}
+return M

--- a/lua/true-zen/services/mode-focus/service.lua
+++ b/lua/true-zen/services/mode-focus/service.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 
 local cmd = vim.cmd
@@ -6,27 +6,27 @@ local cmd = vim.cmd
 
 -- bottom specific options
 
-function native_focus_true()		-- show
+function M.native_focus_true()		-- show
 
 	cmd("vert resize | resize")
 	cmd("normal! ze")
 
 end
 
-function native_focus_false()		-- don't show
+function M.native_focus_false()		-- don't show
 	
 	cmd("wincmd =")
 	cmd("normal! ze")
 
 end
 
-function experimental_focus_true()
+function M.experimental_focus_true()
 
 	cmd("tabe %")
 	
 end
 
-function experimental_focus_false()
+function M.experimental_focus_false()
 
 	cmd("q")
 	
@@ -35,10 +35,5 @@ end
 
 
 
-return {
-	native_focus_true = native_focus_true,
-	native_focus_false = native_focus_false,
-	experimental_focus_true = experimental_focus_true,
-	experimental_focus_false = experimental_focus_false
-}
+return M
 

--- a/lua/true-zen/services/mode-minimalist/init.lua
+++ b/lua/true-zen/services/mode-minimalist/init.lua
@@ -1,4 +1,5 @@
-
+local M = {}
+local minimalist_show
 
 local service = require("true-zen.services.mode-minimalist.service")
 local opts = require("true-zen.config").options
@@ -92,7 +93,7 @@ local function toggle()
 end
 
 
-function main(option)
+function M.main(option)
 
 	option = option or 0
 
@@ -108,6 +109,4 @@ function main(option)
 end
 
 
-return {
-	main = main
-}
+return M

--- a/lua/true-zen/services/mode-minimalist/service.lua
+++ b/lua/true-zen/services/mode-minimalist/service.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local bottom = require("true-zen.services.bottom.init")
 local top = require("true-zen.services.top.init")
@@ -6,13 +6,13 @@ local left = require("true-zen.services.left.init")
 
 -- bottom specific options
 
-function minimalist_true()		-- show
+function M.minimalist_true()		-- show
 	bottom.main(1)
 	top.main(1)
 	left.main(1)
 end
 
-function minimalist_false()		-- don't show
+function M.minimalist_false()		-- don't show
 	bottom.main(2)
 	top.main(2)
 	left.main(2)
@@ -20,8 +20,5 @@ end
 
 
 
-return {
-	minimalist_true = minimalist_true,
-	minimalist_false = minimalist_false
-}
+return M
 

--- a/lua/true-zen/services/top/init.lua
+++ b/lua/true-zen/services/top/init.lua
@@ -1,40 +1,41 @@
+local M = {}
 
 local service = require("true-zen.services.top.service")
 local cmd = vim.cmd
 
 -- show and hide top funcs
 local function top_true()
-	top_show = 1
+	M.top_show = 1
 	service.top_true()
 end
 
 local function top_false()
-	top_show = 0
+	M.top_show = 0
 	service.top_false()
 end
 
 local function toggle()
-	top_show = vim.api.nvim_eval("&showtabline > 0")
-	if (top_show == 1) then				-- status line true, shown; thus, hide
+	M.top_show = vim.api.nvim_eval("&showtabline > 0")
+	if (M.top_show == 1) then				-- status line true, shown; thus, hide
 		top_false()
-	elseif (top_show == 0) then			-- status line false, hidden; thus, show
+	elseif (M.top_show == 0) then			-- status line false, hidden; thus, show
 		top_true()
 	else
 		-- nothing
 	end
 end
 
-function resume()
+function M.resume()
 
-	if (top_show == 1) then				-- status line true; shown
+	if (M.top_show == 1) then				-- status line true; shown
 		-- cmd("echo 'I was set to true so I am turning status line on'")
 		top_true()
-	elseif (top_show == 0) then			-- status line false; hidden
+	elseif (M.top_show == 0) then			-- status line false; hidden
 		-- cmd("echo 'I was set to false so I am turning status line off'")
 		top_false()
-	elseif (top_show == nil) then			-- show var is nil
+	elseif (M.top_show == nil) then			-- show var is nil
 		-- cmd("echo 'I was not set to anything so I am nil'")
-		top_show = vim.api.nvim_eval("&showtabline > 0")
+		M.top_show = vim.api.nvim_eval("&showtabline > 0")
 	else
 		cmd("echo 'none of the above'")
 		-- nothing
@@ -42,7 +43,7 @@ function resume()
 end
 
 
-function main(option)
+function M.main(option)
 
 	option = option or 0
 
@@ -65,8 +66,4 @@ end
 -- 	augroup END
 -- ]], false)
 
-return {
-	main = main,
-	resume = resume,
-	top_show = top_show
-}
+return M

--- a/lua/true-zen/services/top/service.lua
+++ b/lua/true-zen/services/top/service.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local opts = require("true-zen.config").options
 local cmd_settings = require("true-zen.utils.cmd_settings")
@@ -6,20 +6,17 @@ local cmd_settings = require("true-zen.utils.cmd_settings")
 -- top specific options
 -- set showtabline=<num>
 
-function top_true()		-- show
+function M.top_true()		-- show
 	-- vim.cmd("echo 'I RAN TRUE'")
 	cmd_settings.map_settings(opts["top"], true, "TOP")
 end
 
-function top_false()		-- don't show
+function M.top_false()		-- don't show
 	-- vim.cmd("echo 'I RAN FALSE'")
 	cmd_settings.map_settings(opts["top"], false, "TOP")
 end
 
 
 
-return {
-	top_true = top_true,
-	top_false = top_false
-}
+return M
 

--- a/lua/true-zen/utils/before_after_cmd.lua
+++ b/lua/true-zen/utils/before_after_cmd.lua
@@ -1,9 +1,12 @@
-
+local M = {}
+local left_has_been_stored, left_has_been_restored, user_left_opts
+local top_has_been_stored, top_has_been_restored, user_top_opts
+local bottom_has_been_stored, bottom_has_been_restored, user_bottom_opts
 
 -- local opts = require("true-zen.config").options
 local cmd = vim.cmd
 
-function get_has_been_stored(element)
+function M.get_has_been_stored(element)
 	if (element == "LEFT") then
 		return left_has_been_stored
 	elseif (element == "TOP") then
@@ -13,7 +16,7 @@ function get_has_been_stored(element)
 	end
 end
 
-function set_has_been_stored(element, val)
+function M.set_has_been_stored(element, val)
 	if (element == "LEFT") then
 		left_has_been_stored = val
 	elseif (element == "TOP") then
@@ -23,7 +26,7 @@ function set_has_been_stored(element, val)
 	end
 end
 
-function get_has_been_restored(element)
+function M.get_has_been_restored(element)
 	if (element == "LEFT") then
 		return left_has_been_restored
 	elseif (element == "TOP") then
@@ -64,6 +67,7 @@ local function clean_and_append(opt, table_opt, remove_str)
 	local final_opt = opt:gsub(remove_str, "")
 
 
+	local to_cmd
 	if (type(table_opt) == "boolean") then
 		to_cmd = test_bool(final_opt, table_opt)
 		-- cmd("echo 'To cmd = "..tostring(to_cmd).."'")
@@ -91,7 +95,7 @@ local function read_call(opt, value_opt)
 	
 end
 
-function store_settings(table_local, ui_element)
+function M.store_settings(table_local, ui_element)
 
 
 	if (ui_element == "TOP") then
@@ -146,7 +150,7 @@ function store_settings(table_local, ui_element)
 	
 end
 
-function restore_settings(ui_element)
+function M.restore_settings(ui_element)
 
 	ui_element = ui_element or "NONE"
 
@@ -198,11 +202,4 @@ end
 
 
 
-return {
-	store_settings = store_settings,
-	restore_settings = restore_settings,
-	get_has_been_stored = get_has_been_stored,
-	get_has_been_restored = get_has_been_restored,
-	set_has_been_stored = set_has_been_stored
-}
-
+return M

--- a/lua/true-zen/utils/cmd_settings.lua
+++ b/lua/true-zen/utils/cmd_settings.lua
@@ -1,4 +1,4 @@
-
+local M = {}
 
 local cmd = vim.cmd
 local opts = require("true-zen.config").options
@@ -24,8 +24,9 @@ local function test_str(final_opt, str)
 end
 
 local function clean_and_exec(opt, table_opt, remove_str)
-	final_opt = opt:gsub(remove_str, "")
+	local final_opt = opt:gsub(remove_str, "")
 
+	local to_cmd
 	if (type(table_opt) == "boolean") then
 		to_cmd = test_bool(final_opt, table_opt)
 		cmd(to_cmd)
@@ -39,7 +40,7 @@ local function clean_and_exec(opt, table_opt, remove_str)
 end
 
 
-function map_settings(table, bool, ui_element)
+function M.map_settings(table, bool, ui_element)
 
 	ui_element = ui_element or "NONE"
 
@@ -113,6 +114,4 @@ end
 
 
 
-return {
-	map_settings = map_settings
-}
+return M

--- a/plugin/true-zen-cmds.vim
+++ b/plugin/true-zen-cmds.vim
@@ -9,7 +9,7 @@ let s:save_cpo = &cpo " save user coptions
 set cpo&vim " reset them to defaults
 
 " command! -nargs=* Sub call MapArgs(<f-args>) | lua require("t2").parse_and_categorize("hehe")
-function! MapArgs(...)
+function! s:MapArgs(...)
 	if (a:0 > 4)
 		echom "TrueZen: you cannot pass more than 4 arguments to this command."
 	else
@@ -37,7 +37,7 @@ endfunction
 " mapping {{{
 " modes
 " command! TZAtaraxis lua require'true-zen.main'.main(4, 0)
-command! -nargs=* TZAtaraxis call MapArgs(<f-args>) | lua require'true-zen.main'.main(4, 0)
+command! -nargs=* TZAtaraxis call s:MapArgs(<f-args>) | lua require'true-zen.main'.main(4, 0)
 command! TZMinimalist lua require'true-zen.main'.main(3, 0)
 command! TZFocus lua require'true-zen.main'.main(5, 0)
 


### PR DESCRIPTION
Reasons for commit:
- Indenting in lua often uses two spaces. This is followed in Programming in Lua, the Lua Reference Manual, Beginning Lua Programming, and the Lua users wiki. Furthermore, according to luarocks, "One should not use tabs for indentation, or mix it with spaces."
- People copy pasting the readme will face formatting issues.

I am sure there are other places in the repo that should also be changed, so I'll let those up to you, or you can just let me know which files to change.

@kdav5758 